### PR TITLE
rd_tool with JSON output

### DIFF
--- a/pylib/encoders.py
+++ b/pylib/encoders.py
@@ -8,6 +8,8 @@ import os
 from subprocess import check_call, check_output
 import subprocess
 
+import y4m
+
 def _remove_file_if_exists(file_path):
     if path.exists(file_path):
         os.remove(file_path)
@@ -21,15 +23,19 @@ def _predict_binary_search(min_q, max_q, steps):
     return [(min_q + max_q) // 2**i for i in range(1, steps + 1)]
 
 class Encoder(object):
+    binaries = []
     min_q = None
     max_q = None
 
-    def __init__(self, daala_root):
-        self.daala_root = daala_root
+    def __init__(self, paths):
+        self._paths = paths
 
     @classmethod
     def name(cls):
         return cls.__name__.lower()
+
+    def _path_to(self, binary):
+        return self._paths[binary]
 
     def encode_and_dump(self, input_y4m, output_y4m, q, extra_options=[]):
         """Encode a raw file and dump the result to a raw file again.
@@ -38,7 +44,8 @@ class Encoder(object):
 
     def get_version(self):
         """Get a version string"""
-        raise NotImplementedError()
+        encoder_binary = self._path_to(self.binaries[0])
+        return check_output([encoder_binary, '--version'], stderr=subprocess.STDOUT).decode().strip()
 
     def default_qualities(self):
         """List of quality parameters to use by default"""
@@ -46,15 +53,12 @@ class Encoder(object):
 
 
 class Daala(Encoder):
+    binaries = ['daala']
     min_q = 1
     max_q = 511
 
-    def _encoder_path(self):
-        """Path to encoder_example binary"""
-        return self.daala_root + '/examples/encoder_example'
-
     def encode_and_dump(self, input_y4m, output_y4m, q, extra_options=[]):
-        encoder_example = self._encoder_path()
+        encoder_example = self._path_to('daala')
         output_encoded = output_y4m + '.ogv'
         basename = path.basename(output_y4m)
         env = {
@@ -76,10 +80,6 @@ class Daala(Encoder):
         _remove_file_if_exists(basename + '-enc.out')
         return output_encoded, encode_cmd
 
-    def get_version(self):
-        encoder_example = self._encoder_path()
-        return check_output([encoder_example, '--version'], stderr=subprocess.STDOUT).decode().strip()
-
     def default_qualities(self):
         # 256, 128, 64, 32 will probably be hit by the binary search, but start
         # them at once to improve utilization.
@@ -88,13 +88,98 @@ class Daala(Encoder):
         return warmup + [5, 8, 400]
 
 
-all_encoders = [Daala]
+class X264(Encoder):
+    binaries = ['x264']
+    min_q = 1
+    max_q = 51
+
+    def encode_and_dump(self, input_y4m, output_y4m, q, extra_options=[]):
+        x264 = self._path_to('x264')
+        output_encoded = output_y4m + '.x264'
+
+        logfile = path.basename(output_y4m) + '-enc.out'
+        yuv_tmp_base, y4m_ext = path.splitext(output_y4m)
+        assert y4m_ext == '.y4m', 'yuv2yuv4mpeg only outputs to .y4m'
+
+        with open(logfile, 'wb') as enc_log:
+            encode_cmd = [x264, '--preset=placebo', '--min-keyint=256', '--keyint=256', '--no-scenecut', '--crf', str(q), '--output', output_encoded, '--dump-yuv', yuv_tmp_base + '.yuv', input_y4m] + extra_options
+            check_call(
+                encode_cmd,
+                stderr=enc_log
+            )
+
+        self.convert_yuv_dump_to_y4m(input_y4m, yuv_tmp_base)
+
+        _remove_file_if_exists(yuv_tmp_base + '.yuv')
+        _remove_file_if_exists(logfile)
+        return output_encoded, encode_cmd
+
+    def convert_yuv_dump_to_y4m(self, input_y4m, basename):
+        """Converts basename.yuv to basename.y4m.
+        The original input y4m is used to determine the width and height of the file.
+        """
+        with open(input_y4m, 'rb') as y4m_file:
+            input_header = y4m.read_header(y4m_file)
+        width, height = input_header['W'], input_header['H']
+        yuv2yuv4mpeg = path.join(self._path_to('tools'), 'tools', 'yuv2yuv4mpeg')
+        check_call([yuv2yuv4mpeg, basename, '-w{0}'.format(width), '-h{0}'.format(height), '-an0', '-ad0', '-c420mpeg2'])
+
+    def default_qualities(self):
+        return list(range(1,52,5))
+
+
+class X265(Encoder):
+    binaries = ['x265']
+    min_q = 5
+    max_q = 51
+
+    args = ['--preset=slow', '--frame-threads=1', '--min-keyint=256', '--keyint=256', '--no-scenecut']
+
+    def encode_and_dump(self, input_y4m, output_y4m, q, extra_options=[]):
+        x265 = self._path_to('x265')
+        output_encoded = output_y4m + '.x265'
+
+        logfile = path.basename(output_y4m) + '-enc.out'
+        with open(logfile, 'wb') as enc_log:
+            encode_cmd = [x265] + self.args + ['--crf', str(q), '-r', output_y4m, '--output', output_encoded, input_y4m] + extra_options
+            check_call(
+                encode_cmd,
+                stdout=enc_log,
+                stderr=subprocess.STDOUT,
+            )
+
+        _remove_file_if_exists(logfile)
+        return output_encoded, encode_cmd
+
+    def default_qualities(self):
+        return list(range(5,52,5))
+
+
+class X265Realtime(X265):
+    args = X265.args + ['--tune=zerolatency', '--rc-lookahead=0', '--bframes=0']
+
+    @classmethod
+    def name(cls):
+        return 'x265-rt'
+
+
+all_encoders = [Daala, X264, X265, X265Realtime]
 
 def get_encoder_names():
     return [cls.name() for cls in all_encoders]
 
-def get_encoder(name, daala_root=None):
+def get_all_binaries():
+    """Get all paths used by encoders, so we can show them as command line options."""
+    binaries = []
+    for cls in all_encoders:
+        for binary in cls.binaries:
+            if binary not in binaries:
+                binaries.append(binary)
+    return binaries
+
+def get_encoder(name, paths={}):
     """Get encoder by name."""
-    if name == 'daala':
-        return Daala(daala_root)
+    for cls in all_encoders:
+        if cls.name() == name:
+            return cls(paths)
     raise ValueError("Unknown encoder name '{}'".format(name))

--- a/pylib/encoders.py
+++ b/pylib/encoders.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python2
+"""
+Information on how to call each encoder
+"""
+
+from os import path
+import os
+from subprocess import check_call, check_output
+import subprocess
+
+def _remove_file_if_exists(file_path):
+    if path.exists(file_path):
+        os.remove(file_path)
+
+def _predict_binary_search(min_q, max_q, steps):
+    """Predict the binary search assuming the steps are all downwards
+
+    >>> _predict_binary_search(1, 511, 4)
+    [256, 128, 64, 32]
+    """
+    return [(min_q + max_q) // 2**i for i in range(1, steps + 1)]
+
+class Encoder(object):
+    min_q = None
+    max_q = None
+
+    def __init__(self, daala_root):
+        self.daala_root = daala_root
+
+    @classmethod
+    def name(cls):
+        return cls.__name__.lower()
+
+    def encode_and_dump(self, input_y4m, output_y4m, q, extra_options=[]):
+        """Encode a raw file and dump the result to a raw file again.
+        Returns a tuple with the path to the encoded intermediate file, and the command line used to run the encoder."""
+        raise NotImplementedError()
+
+    def get_version(self):
+        """Get a version string"""
+        raise NotImplementedError()
+
+    def default_qualities(self):
+        """List of quality parameters to use by default"""
+        raise NotImplementedError()
+
+
+class Daala(Encoder):
+    min_q = 1
+    max_q = 511
+
+    def _encoder_path(self):
+        """Path to encoder_example binary"""
+        return self.daala_root + '/examples/encoder_example'
+
+    def encode_and_dump(self, input_y4m, output_y4m, q, extra_options=[]):
+        encoder_example = self._encoder_path()
+        output_encoded = output_y4m + '.ogv'
+        basename = path.basename(output_y4m)
+        env = {
+            'OD_LOG_MODULES': 'encoder:10',
+            'OD_DUMP_IMAGES_SUFFIX': basename,
+        }
+        with open(basename + '-enc.out', 'wb') as enc_log:
+            encode_cmd = [encoder_example, '--keyframe-rate=256', '--video-quality', str(q), '--output', output_encoded, input_y4m] + extra_options
+            check_call(
+                encode_cmd,
+                env=env,
+                stderr=enc_log
+            )
+        try:
+            dumped_file = '00000000out-' + basename + '.y4m'
+            os.rename(dumped_file, output_y4m)
+        except OSError as e:
+            raise RuntimeError("Could not find {0}, is daala configured with --enable-dump-recons?".format(dumped_file), e)
+        _remove_file_if_exists(basename + '-enc.out')
+        return output_encoded, encode_cmd
+
+    def get_version(self):
+        encoder_example = self._encoder_path()
+        return check_output([encoder_example, '--version'], stderr=subprocess.STDOUT).decode().strip()
+
+    def default_qualities(self):
+        # 256, 128, 64, 32 will probably be hit by the binary search, but start
+        # them at once to improve utilization.
+        warmup = _predict_binary_search(self.min_q, self.max_q, 4)
+        # Add some extremes on each end
+        return warmup + [5, 8, 400]
+
+
+all_encoders = [Daala]
+
+def get_encoder_names():
+    return [cls.name() for cls in all_encoders]
+
+def get_encoder(name, daala_root=None):
+    """Get encoder by name."""
+    if name == 'daala':
+        return Daala(daala_root)
+    raise ValueError("Unknown encoder name '{}'".format(name))

--- a/pylib/executor.py
+++ b/pylib/executor.py
@@ -82,6 +82,7 @@ class Task(namedtuple('Task', 'priority, name, arguments')):
     # We inherit a sort order from namedtuple
 
     MAX_PRIORITY = 0
+    MIN_PRIORITY = 10000
 
     def __init__(self, priority, name, arguments):
         super(Task, self).__init__(priority, name, arguments)

--- a/pylib/executor.py
+++ b/pylib/executor.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python2
+"""
+Code for running task concurrently on remote servers via SSH
+"""
+
+from collections import namedtuple
+import json
+import logging
+from os import path
+import Queue as queue
+import subprocess
+import threading
+
+log = logging.getLogger('executor')
+
+
+def make_local_pool(rd_tool_dir, num_threads=1):
+    """Get a pool that executes tasks by running them on the local machine."""
+    task_queue = queue.PriorityQueue()
+    executor = LocalMachineExecutor(rd_tool_dir)
+    threads = [Worker(task_queue, executor) for i in range(num_threads)]
+    for thread in threads:
+        thread.start()
+    log.debug('Created local executor with %d workers', len(threads))
+    return Pool(task_queue, threads, executor)
+
+
+def run_in_thread(func, args=[], kwargs={}):
+    """Call function in a new thread and return a future that will receive the return value."""
+    result_future = Future()
+    def call_func():
+        try:
+            result = func(*args, **kwargs)
+        except BaseException as e:
+            log.debug('Thread failed:', exc_info=True)
+            result_future.set_exception(e)
+        else:
+            result_future.set_result(result)
+    thread = threading.Thread(target=call_func)
+    thread.daemon = True
+    thread.start()
+    return result_future
+
+
+class Future:
+    def __init__(self):
+        self._done = threading.Event()
+        self._failed = False
+        self._exception = None
+        self._result = None
+
+    def set_result(self, result):
+        """Set the result of this future"""
+        if self._done.is_set():
+            raise Exception('Future can only be resolved once')
+        self._result = result
+        self._done.set()
+
+    def set_exception(self, exception):
+        """Set an exception to be raised by result()"""
+        if self._done.is_set():
+            raise Exception('Future can only be resolved once')
+        self._failed = True
+        self._exception = exception
+        self._done.set()
+
+    def result(self):
+        """Get the result of the future. Blocks until the future is done."""
+        self._done.wait()
+        if self._failed:
+            raise self._exception
+        return self._result
+
+
+class Task(namedtuple('Task', 'priority, name, arguments')):
+    """Represents a task to be executed
+    Tasks are placed under the task/ folder, are run with the passed arguments,
+    and output a JSON line that is returned as the result.
+    If multiple tasks are waiting to be executed, the task with the lowest
+    priority should run first.
+    """
+    # We inherit a sort order from namedtuple
+
+    MAX_PRIORITY = 0
+
+    def __init__(self, priority, name, arguments):
+        super(Task, self).__init__(priority, name, arguments)
+        self.future = Future()
+
+    def set_result(self, result):
+        """Set the result, or a TaskFailed exception if the task failed"""
+        log.debug('Got result %r for %r', result, self)
+        self.future.set_result(result)
+
+    def set_exception(self, exception):
+        log.debug('Got exception %r for %r', exception, self)
+        self.future.set_exception(exception)
+
+    def result(self):
+        """Get the result of the task. Blocks until the task is done. Throws TaskFailed if the task failed."""
+        return self.future.result()
+
+
+class LazyTask:
+    """Wrapper for Task that lazily executes it when the result is accessed."""
+    def __init__(self, task, pool):
+        self.task = task
+        self.pool = pool
+        self.enqueued = False
+        self.enqueue_lock = threading.Lock()
+
+    def ensure_enqueued(self):
+        with self.enqueue_lock:
+            if not self.enqueued:
+                self.pool.enqueue_task(self.task)
+                self.enqueued = True
+
+    def is_enqueued_or_completed(self):
+        """Check if the wrapped task is enqueued or completed"""
+        with self.enqueue_lock:
+            return self.enqueued
+
+    def result(self):
+        """Get the result of the task, blocking until ready."""
+        self.ensure_enqueued()
+        return self.task.result()
+
+
+class TaskFailed(Exception):
+    pass
+
+
+class Worker(threading.Thread):
+    """A worker thread represents one machine slot.
+    It grabs tasks from the queue and runs them with the executor.
+    """
+
+    def __init__(self, task_queue, executor):
+        super(Worker, self).__init__()
+        self.task_queue = task_queue
+        self.executor = executor
+        self._stop = threading.Event()
+        self.daemon = True
+
+    def stop(self):
+        self._stop.set()
+
+    def run(self):
+        while not self._stop.is_set():
+            try:
+                task = self.task_queue.get(timeout=1)
+                self.executor.execute(task)
+            except queue.Empty:
+                pass
+
+
+class Pool:
+    def __init__(self, task_queue, threads, executor):
+        self.task_queue = task_queue
+        self.threads = threads
+        self.stopped = False
+        self.executor = executor
+        self._on_enqueue = None
+
+    def await_task(self, task):
+        """Wait for a task to execute and return the result"""
+        self.enqueue_task(task)
+        return task.result()
+
+    def enqueue_task(self, task):
+        """Execute a task asynchronously. The result is stored in the task."""
+        if self.stopped:
+            raise RuntimeError("Cannot run tasks after shutdown")
+        log.debug('Enqueueing task %r', task)
+        if self._on_enqueue is not None:
+            self._on_enqueue()
+        self.task_queue.put(task)
+
+    def shutdown(self):
+        self.stopped = True
+        for thread in self.threads:
+            thread.stop()
+        log.debug('Waiting for workers...')
+        for thread in self.threads:
+            thread.join()
+        log.debug('Workers stopped!')
+        while not self.task_queue.empty():
+            self.task_queue.get().set_exception(TaskFailed('Shutdown'))
+
+    def set_on_enqueue(self, on_enqueue):
+        self._on_enqueue = on_enqueue
+
+    def set_on_execute(self, on_execute):
+        self.executor.on_execute = on_execute
+
+    def set_on_complete(self, on_complete):
+        self.executor.on_complete = on_complete
+
+    def set_on_failure(self, on_failure):
+        self.executor.on_failure = on_failure
+
+
+class LocalMachineExecutor:
+    """Executor that runs tasks locally."""
+
+    on_execute = None
+    on_complete = None
+    on_failure = None
+    def __init__(self, rd_tool_dir):
+        self.rd_tool_dir = rd_tool_dir
+
+    def execute(self, task):
+        """Run a task and set its result. Called by Worker threads."""
+        if self.on_execute:
+            self.on_execute()
+        task_path = path.join(self.rd_tool_dir, 'tasks', task.name)
+        try:
+            cmd = [task_path] + task.arguments
+            log.debug('Running command %r', cmd)
+            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+            result = json.loads(output)
+            task.set_result(result)
+            if self.on_complete:
+                self.on_complete()
+            return
+        except subprocess.CalledProcessError as e:
+            task.set_exception(TaskFailed('{0} failed with return code {1} and output "{2}"'.format(task, e.returncode, e.output)))
+        except ValueError as e:
+            task.set_exception(TaskFailed('{0} returned unparsable output "{1}"'.format(task, output)))
+        except BaseException as e:
+            task.set_exception(TaskFailed('{0} failed with unhandled exception "{1}"'.format(task, e)))
+        if self.on_failure:
+            self.on_failure()

--- a/pylib/metrics.py
+++ b/pylib/metrics.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python2
+"""
+Metric calculations
+"""
+
+from os import path
+from subprocess import check_output
+import subprocess
+import re
+
+
+def parse_total_line(line):
+    r"""Parse the total line from the dump tools to a dict with "Total", "Y'", "Cb" and "Cr"
+
+    >>> sorted(parse_total_line("Total: 8.57963   (Y': 8.23833   Cb: 8.90916   Cr: 9.85199 )\n").items())
+    [('Cb', 8.90916), ('Cr', 9.85199), ('Total', 8.57963), ("Y'", 8.23833)]
+    """
+    match = re.match(r"^Total: (?P<Total>[\d\.]*)\s+\(Y': (?P<Y>[\d\.]*)\s+Cb: (?P<Cb>[\d\.]*)\s+Cr: (?P<Cr>[\d\.]*)\s*\)\s*$", line)
+    groups = match.groupdict()
+    return {
+        "total": float(groups['Total']),
+        "Y'": float(groups['Y']),
+        "Cb": float(groups['Cb']),
+        "Cr": float(groups['Cr']),
+    }
+
+
+class ToolMetric(object):
+    """Base class for the dump_* tools in the daala repo"""
+    def __init__(self, daala_root):
+        self.daala_root = daala_root
+
+    @classmethod
+    def name(cls):
+        return cls.__name__.lower()
+
+    def _get_cmd(self):
+        """Get the command to run, """
+        tool_name = 'dump_{0}'.format(self.name())
+        return [path.join(self.daala_root, 'tools', tool_name), '-s']
+
+    def calculate(self, original_y4m, result_y4m):
+        cmd = self._get_cmd() + [original_y4m, result_y4m]
+        output = check_output(cmd, stderr=subprocess.STDOUT)
+        total_line = next(line for line in output.splitlines() if line.startswith(b'Total:'))
+        return parse_total_line(total_line)
+
+
+class Psnr(ToolMetric):
+    pass
+
+class Psnrhvs(ToolMetric):
+    pass
+
+class Ssim(ToolMetric):
+    pass
+
+class Fastssim(ToolMetric):
+    def _get_cmd(self):
+        # dump_fastssim requires a '-c' argument to get the same output format as the others
+        return super(Fastssim, self)._get_cmd() + ['-c']
+
+
+all_metrics = [Psnr, Psnrhvs, Ssim, Fastssim]
+
+def get_all_metrics(daala_root):
+    return [cls(daala_root) for cls in all_metrics]

--- a/pylib/y4m.py
+++ b/pylib/y4m.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python2
+"""
+Utility functions for parsing y4m files
+"""
+
+from fractions import Fraction
+
+
+def read_file(fileobj):
+    """Iterate over the parts of a y4m file
+
+    Returns a (header, frame_iterator) tuple, where frame_iterator returns (frame_header, frame_data) tuples
+    """
+    header = fileobj.readline()
+    params = parse_header(header)
+    width, height = int(params[b'W']), int(params[b'H'])
+    frame_bytes = frame_size(width, height, params[b'C'])
+    return (header, _iterate_over_frames(fileobj, frame_bytes))
+
+
+def _iterate_over_frames(fileobj, frame_bytes):
+    """Yield a (header, frame_data) pair for each frame encountered in the file"""
+    while True:
+        frame_header = fileobj.readline()
+        if frame_header == b'':
+            return # EOF
+        if not frame_header.startswith(b'FRAME'):
+            raise ValueError('Expected frame header')
+        frame = fileobj.read(frame_bytes)
+        if len(frame) < frame_bytes:
+            raise ValueError('Read truncated frame')
+        yield (frame_header, frame)
+
+
+def parse_header(header):
+    """Parse a y4m header to a dict of parameter values
+
+    >>> sorted(parse_header("YUV4MPEG2 W640 H400 F24:1 Ip A1:1 C420jpeg XYSCSS=420JPEG").items())
+    [('A', '1:1'), ('C', '420jpeg'), ('F', '24:1'), ('H', '400'), ('I', 'p'), ('W', '640'), ('X', 'YSCSS=420JPEG')]
+    """
+    if not header.startswith(b'YUV4MPEG2 '):
+        raise ValueError('Not a valid y4m header')
+    params = dict((param[:1], param[1:]) for param in header.split(b' ')[1:])
+    return params
+
+
+def frame_size(width, height, subsampling):
+    """Get the frame size in bytes from the dimensions and subsampling
+
+    >>> frame_size(640, 400, b'420jpeg')
+    384000
+    """
+    multipliers = {
+        b'444': 3,
+        b'422': 2,
+        b'420': Fraction(3, 2),
+        b'420jpeg': Fraction(3, 2),
+        b'420paldv': Fraction(3, 2),
+    }
+    return int(width * height * multipliers[subsampling])

--- a/pylib/y4m.py
+++ b/pylib/y4m.py
@@ -17,6 +17,11 @@ def read_file(fileobj):
     frame_bytes = frame_size(width, height, params[b'C'])
     return (header, _iterate_over_frames(fileobj, frame_bytes))
 
+def read_header(fileobj):
+    """Parse the header of a file and return it as a dict"""
+    header, _ = read_file(fileobj)
+    return parse_header(header)
+
 
 def _iterate_over_frames(fileobj, frame_bytes):
     """Yield a (header, frame_data) pair for each frame encountered in the file"""
@@ -40,7 +45,7 @@ def parse_header(header):
     """
     if not header.startswith(b'YUV4MPEG2 '):
         raise ValueError('Not a valid y4m header')
-    params = dict((param[:1], param[1:]) for param in header.split(b' ')[1:])
+    params = dict((param[:1], param[1:].strip()) for param in header.split(b' ')[1:])
     return params
 
 

--- a/rd_tool_json.py
+++ b/rd_tool_json.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python2
+
+"""
+Encode a set of files on Amazon EC2 instances and save a report with rate-distortion info in JSON format.
+"""
+
+import argparse
+import bisect
+import datetime
+from functools import total_ordering
+import json
+import logging
+from multiprocessing import cpu_count
+from os import path
+import sys
+import threading
+import time
+
+THIS_DIR = path.dirname(sys.argv[0])
+sys.path.append(path.join(THIS_DIR, 'pylib'))
+from executor import make_local_pool, run_in_thread, Task, LazyTask, TaskFailed
+from encoders import get_encoder, get_encoder_names
+
+REMOTE_DAALA_ROOT = '/home/ec2-user/daala/'
+REMOTE_SETS_DIR = '/home/ec2-user/sets/'
+
+TARGET_BITS_PER_PIXEL = [0.05, 0.1]
+
+def make_report(run_id, set_name, sets_dir, daala_root, encoder, pool):
+    start_time = datetime.datetime.utcnow()
+
+    set_files = get_sets()[set_name]
+
+    logging.info('Set has %d files', len(set_files))
+    total_files.set(len(set_files))
+
+    file_paths = [path.join(sets_dir, set_name, file_name) for file_name in set_files]
+
+    # Start jobs for each file
+    file_jobs = {}
+    for file_path in file_paths:
+        file_jobs[path.basename(file_path)] = run_in_thread(make_report_for_file, [], {
+            'run_id': run_id,
+            'file_path': file_path,
+            'daala_root': daala_root,
+            'encoder': encoder,
+            'pool': pool,
+        })
+
+    # Gather job results, waiting for jobs to finish
+    file_reports = {}
+    for file_name, job in file_jobs.items():
+        result = job.result()
+        file_reports[file_name] = result
+
+    return {
+        'run_id': run_id,
+        'set': set_name,
+        'date': start_time.isoformat() + 'Z',
+        'files': file_reports,
+    }
+
+def make_report_for_file(run_id, file_path, daala_root, encoder, pool):
+    """Encode a file at several quality levels and return a report."""
+    # Start by gathering information on the file
+    file_info = pool.await_task(Task(Task.MAX_PRIORITY, 'y4m_info.py', [file_path]))
+    file_size = file_info['bytes']
+    file_pixels = file_info['pixels']
+
+    # Make tasks for all possible quality parameters, from lowest quality
+    # (high q) to highest (low q). Only the ones accessed by the binary search
+    # will actually be run.
+    encode_tasks = []
+    for q in range(encoder.max_q, encoder.min_q - 1, -1):
+    #for q in range(16, 8, -1):
+        run_name = '{0}-{1}-{2}'.format(run_id, path.basename(file_path), q)
+        task = Task(
+            priority = estimate_priority(file_size, q),
+            name = 'run_encoder.py',
+            arguments = ['--codec', encoder.name(), '--run-name', run_name, '--daala-root', daala_root, str(q), file_path]
+        )
+        encode_tasks.append(LazyTask(task, pool))
+
+    # Start tasks for extra quality levels
+    for q in encoder.default_qualities():
+        encode_tasks[encoder.max_q - q].ensure_enqueued()
+
+    # Start searches for binary tasks in separate threads
+    # They'll be accessing the same encode_tasks array, sharing the results
+    target_bpp_jobs = {}
+    for bpp in TARGET_BITS_PER_PIXEL:
+        target_size = bytes_for_bpp(bpp, file_pixels)
+        target_bpp_jobs[str(bpp)] = run_in_thread(search_for_size, [encode_tasks, target_size])
+
+    # Run search tasks to completion and gather the results
+    bpp_to_quality = {}
+    for bpp, job in target_bpp_jobs.items():
+        if job.result() == None:
+            bpp_to_quality[bpp] = None
+        else:
+            bpp_to_quality[bpp] = encode_tasks[job.result()].result()['quality']
+
+    # Collect info from the tasks that have been run
+    encode_info = []
+    for task in encode_tasks:
+        if task.is_enqueued_or_completed():
+            try:
+                result = task.result()
+            except TaskFailed as e:
+                logging.warning('Task failed: %r', e)
+                result = {'error': repr(e)}
+            encode_info.append(result)
+
+    completed_files.increment()
+    return {
+        'info': file_info,
+        'encodes': encode_info,
+        'bpp_to_quality': bpp_to_quality,
+    }
+
+
+@total_ordering
+class TargetSize:
+    """Compares itself to encode tasks using the encoded file size"""
+    def __init__(self, target_bytes):
+        self.target_bytes = target_bytes
+    def __lt__(self, encode_task):
+        return self.target_bytes < encode_task.result()['bytes']
+    def __eq__(self, encode_task):
+        return self.target_bytes == encode_task.result()['bytes']
+
+
+def search_for_size(encode_tasks, target_size):
+    """Search for an encode smaller or equal to a target size.
+    Returns the index of the encode, or None if no smaller encodes are found."""
+    right_of_target = bisect.bisect_right(encode_tasks, TargetSize(target_size))
+    if right_of_target == 0:
+        return None
+    else:
+        return right_of_target - 1
+
+
+def get_sets():
+    return json.load(open(path.join(THIS_DIR, 'sets.json'), 'r'))
+
+def estimate_priority(file_size, quality):
+    """
+    >>> estimate_priority(1e7, 10) < estimate_priority(1e6, 10)
+    True
+    >>> estimate_priority(1e6, 10) < estimate_priority(1e6, 50)
+    True
+    >>> estimate_priority(5000, 10) < estimate_priority(5500, 12)
+    False
+    >>> estimate_priority(5000, 10) < estimate_priority(5500, 100)
+    True
+    """
+    # Do a very rough estimate of running time based on file size and quality
+    # The idea is that we want to run the longer-running tasks first, so we
+    # don't end up waiting for a single long-running task at the end while the
+    # rest of the cores sit idle.
+    from math import atan
+    return 5 - atan(file_size / atan(2 + quality / 10.0))
+
+def bytes_for_bpp(bpp, pixels):
+    return (bpp * pixels) // 8
+
+
+class Counter:
+    """Atomic counter for stats"""
+    def __init__(self):
+        self.lock = threading.Lock()
+        self._value = 0
+    def set(self, value):
+        with self.lock: self._value = value
+    def get(self):
+        with self.lock: return self._value
+    def increment(self, increment=1):
+        with self.lock: self._value += increment
+    def decrement(self, decrement=1):
+        self.increment(-decrement)
+
+enqueued_tasks = Counter()
+executing_tasks = Counter()
+completed_tasks = Counter()
+failed_tasks = Counter()
+total_tasks = Counter()
+completed_files = Counter()
+total_files = Counter()
+
+def print_progress(delay):
+    while True:
+        time.sleep(delay)
+        logging.info("%d out of %d files completed.", completed_files.get(), total_files.get())
+        logging.info("%d tasks waiting, %d tasks running, %d tasks completed, %d tasks failed", enqueued_tasks.get(), executing_tasks.get(), completed_tasks.get(), failed_tasks.get())
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--run-id', default='unnamed_run', help='name to identify the run')
+    parser.add_argument('--codec', default='daala', choices=get_encoder_names(), help='codec to use')
+    parser.add_argument('--sets-dir', default=REMOTE_SETS_DIR, help='directory with files to encode, organized by set')
+    parser.add_argument('--set', required=True, help='name of file set to encode')
+    parser.add_argument('--daala-root', default=REMOTE_DAALA_ROOT, help='path to daala')
+    parser.add_argument('--progress-interval', type=int, default=30, help='how often to print progress report')
+    parser.add_argument('--verbose', '-v', action='store_true', help='more verbose logging')
+    parser.add_argument('--quiet', '-q', action='store_true', help='less verbose logging')
+    args = parser.parse_args()
+
+    if args.quiet:
+        loglevel = logging.WARNING
+    elif args.verbose:
+        loglevel = logging.DEBUG
+    else:
+        loglevel = logging.INFO
+
+    logging.basicConfig(format='%(asctime)s %(levelname)-8s %(name)s: %(message)s', level=loglevel)
+
+    encoder = get_encoder(args.codec)
+    pool = make_local_pool(THIS_DIR, num_threads=cpu_count())
+
+    # progress tracking
+    pool.set_on_enqueue(lambda: (total_tasks.increment(), enqueued_tasks.increment()))
+    pool.set_on_execute(lambda: (enqueued_tasks.decrement(), executing_tasks.increment()))
+    pool.set_on_complete(lambda: (executing_tasks.decrement(), completed_tasks.increment()))
+    pool.set_on_failure(lambda: (executing_tasks.decrement(), failed_tasks.increment()))
+
+    if not args.quiet:
+        progress_printer = threading.Thread(target=print_progress, args=[args.progress_interval])
+        progress_printer.daemon = True
+        progress_printer.start()
+
+    start_time = time.time()
+    report = make_report(
+        run_id = args.run_id,
+        set_name = args.set,
+        sets_dir = args.sets_dir,
+        daala_root = args.daala_root,
+        encoder = encoder,
+        pool = pool,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    end_time = time.time()
+
+    logging.info('Completed in %d seconds', int(round(end_time - start_time)))
+    logging.info('Total %d tasks, %d completed, %d failed', total_tasks.get(), completed_tasks.get(), failed_tasks.get())
+
+    pool.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/tasks/encoder_version.py
+++ b/tasks/encoder_version.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python2
+
+"""
+Get version of encoders and tools
+"""
+
+from __future__ import print_function
+import argparse
+from os import path
+import json
+import sys
+
+sys.path.append(path.join(path.dirname(sys.argv[0]), '..', 'pylib'))
+from encoders import get_encoder, get_all_binaries
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--codec', default='daala')
+    for bin_name in get_all_binaries():
+        parser.add_argument('--{0}-path'.format(bin_name))
+    parser.add_argument('--tools-root', required=True)
+
+    args = parser.parse_args()
+
+    paths = {}
+    for bin_name in get_all_binaries():
+        bin_path = getattr(args, '{0}_path'.format(bin_name))
+        if bin_path:
+            paths[bin_name] = bin_path
+
+    encoder = get_encoder(args.codec, paths)
+
+    # Use Daala encoder to name the tools repo version
+    tools_daala = get_encoder('daala', {'daala': path.join(args.tools_root, 'examples', 'encoder_example')})
+
+    versions = {
+        'tools_version': tools_daala.get_version(),
+        encoder.name() + '_version': encoder.get_version(),
+    }
+
+    print(json.dumps(versions))
+
+if __name__ == '__main__':
+    main()

--- a/tasks/run_encoder.py
+++ b/tasks/run_encoder.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python2
+"""
+Encode a file at a given quality setting and gather metrics.
+The result is printed to standard output in JSON format.
+"""
+
+from __future__ import print_function
+import argparse
+import json
+from os import path, chdir
+from shutil import rmtree
+import sys
+from tempfile import mkdtemp
+import time
+
+sys.path.append(path.join(path.dirname(sys.argv[0]), '..', 'pylib'))
+from encoders import get_encoder
+from metrics import get_all_metrics
+
+
+def gather_metrics_from_encoder(encoder, metrics, input_y4m, q):
+    output_y4m = '{0}.{1}.y4m'.format(path.basename(input_y4m), q)
+    start_time = time.time()
+    encoded_file, cmd = encoder.encode_and_dump(input_y4m, output_y4m, q)
+    end_time = time.time()
+    encoded_size = path.getsize(encoded_file)
+
+    metrics = calculate_metrics(metrics, input_y4m, output_y4m)
+
+    return {
+        'quality': q,
+        'bytes': encoded_size,
+        'encode_time': int(round(end_time - start_time)),
+        'cmd': cmd,
+        'metrics': metrics,
+    }
+
+
+def calculate_metrics(metrics, original_y4m, result_y4m):
+    results = {"total": {}, "Y'": {}, "Cb": {}, "Cr": {}}
+    for metric in metrics:
+        values = metric.calculate(original_y4m, result_y4m)
+        for plane, value in values.items():
+            results[plane][metric.name()] = value
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--codec', default='daala')
+    parser.add_argument('--keep-temp-files', action='store_true')
+    parser.add_argument('--run-name', default='')
+    parser.add_argument('--daala-root', required=True)
+    parser.add_argument('q', type=int)
+    parser.add_argument('file')
+
+    args = parser.parse_args()
+
+    # Resolve path before we chdir
+    file_path = path.abspath(args.file)
+    daala_root = path.abspath(args.daala_root)
+
+    # Change to a temporary directory so intermediate files end up there
+    temp_dir = mkdtemp(prefix='encode-', suffix=args.run_name)
+    chdir(temp_dir)
+
+    encoder = get_encoder(args.codec, daala_root)
+
+    metrics = get_all_metrics(daala_root)
+
+    output = gather_metrics_from_encoder(encoder, metrics, file_path, args.q)
+
+    print(json.dumps(output))
+
+    if not args.keep_temp_files:
+        # Remove the temporary directory if everything went well
+        rmtree(temp_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/tasks/y4m_info.py
+++ b/tasks/y4m_info.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python2
+
+"""
+Gather info about a y4m file and print it to standard output in JSON format
+Mostly stuff useful for rate calculation.
+"""
+
+from __future__ import print_function
+
+from os import path
+import json
+import sys
+from hashlib import md5
+
+sys.path.append(path.join(path.dirname(sys.argv[0]), '..', 'pylib'))
+import y4m
+
+
+def get_y4m_info(filename):
+    # Could just as well use CRC32 here, but MD5 is more commonly available as a CLI tool for comparison
+    hasher = md5()
+    frame_count = 0
+    with open(filename, 'rb') as y4m_file:
+        header, frames = y4m.read_file(y4m_file)
+        hasher.update(header)
+        params = y4m.parse_header(header)
+        for frame_header, frame_data in frames:
+            frame_count += 1
+            hasher.update(frame_header)
+            hasher.update(frame_data)
+
+    size = path.getsize(filename)
+    width, height = int(params[b'W']), int(params[b'H'])
+    return {
+        'width': width,
+        'height': height,
+        'bytes': size,
+        'frames': frame_count,
+        'frame_rate': params[b'F'],
+        'subsampling': params[b'C'],
+        'md5': hasher.hexdigest(),
+        'pixels': width * height * frame_count,
+    }
+
+
+def main(filename):
+    print(json.dumps(get_y4m_info(filename)))
+
+if __name__ == '__main__':
+    main(sys.argv[1])


### PR DESCRIPTION
Hello,

I mentioned on IRC that I would like to see JSON output and target rate search in rd_tool, to allow for AWCY features like visual comparisons.

This is a tentative implementation. Remote execution is not implemented yet, but the design is intended to work for the same use cases as today. I figured it would be good to check if this looks useful before going further with this.

The improvements on the current rd_tool are:
 - Output data is JSON, making it easy to add new fields. ([Example output](https://gist.github.com/unbounded/3a3c264d01ddfbe36f8c) for a set with a single file.)
 - The tool can do a binary search to find an encode with a desired target rate. All the qualities tried in the binary search are added to the output.

Cons I see are:
 - Binary searching results in more total encodes than the current settings, and adds some sequential dependency, so runs may be slower.
 - The code is more complex and harder to read, and runs in multiple threads.

If this looks sane, my next steps would be to add remote execution and other encoders, to get feature parity with rd_tool.py.
Then I guess at least the following tasks are needed to make it work with AWCY:
 - Figure out how the average curve should work when files are encoded with different qualities
 - Update AWCY to read JSON results
 - Make converter from (and to?) the old result format

I know the code is messy - feel free to point out any comments that need to be added or improved.

Example command line (where "raws" is a test set I'm using locally):
`./rd_tool_json.py --verbose --daala-root /tmp/source/daala --sets-dir /tmp/source/daala --set raws`