### PR TITLE
Get abwork working better

### DIFF
--- a/rd_tool.py
+++ b/rd_tool.py
@@ -185,7 +185,7 @@ machines = awsremote.get_machines(num_instances_to_use, aws_group_name)
 #set up our instances and their free job slots
 for machine in machines:
     machine.setup()
-    
+
 slots = awsremote.get_slots(machines)
 
 # Z is added because that's what awcy uses on the end

--- a/rd_tool.py
+++ b/rd_tool.py
@@ -159,7 +159,7 @@ if not args.individual:
         sys.exit(1)
 
 if not args.individual:
-    total_num_of_jobs = len(video_sets[args.set[0]]) * len(quality[args.codec])
+    total_num_of_jobs = len(video_sets[args.set[0]]['sources']) * len(quality[args.codec])
 else:
     total_num_of_jobs = len(quality[args.codec]) #FIXME
 
@@ -196,7 +196,7 @@ slots = awsremote.get_slots(machines)
 if args.individual:
     video_filenames = args.set
 else:
-    video_filenames = video_sets[args.set[0]]
+    video_filenames = video_sets[args.set[0]]['sources']
 
 if args.mode == 'metric':
     for filename in video_filenames:

--- a/rd_tool.py
+++ b/rd_tool.py
@@ -84,7 +84,7 @@ class ABWork:
         input_path = '/mnt/media/' + work.set + '/' + work.filename
 
         try:
-            slot.start_shell('/home/ec2-user/daala/tools/ab_meta_compare.sh ' + shellquote(str(self.bpp)) + ' ' + shellquote(self.time) + ' ' + work.set + ' ' + shellquote(input_path) )
+            slot.start_shell('/home/ec2-user/daala/tools/ab_meta_compare.sh ' + shellquote(str(self.bpp)) + ' ' + shellquote(self.runid) + ' ' + work.set + ' ' + shellquote(input_path) )
             (stdout, stderr) = slot.gather()
 
             # filename with extension
@@ -93,7 +93,7 @@ class ABWork:
             else:
                 filename = input_path.split('/')[-1].rsplit('.', 1)[0] + '.png'
 
-            middle = self.time + '/' + work.set + '/bpp_' + str(self.bpp)
+            middle = self.runid + '/' + work.set + '/bpp_' + str(self.bpp)
 
             remote_file = '/home/ec2-user/runs/' + middle + '/' + shellquote(filename)
             local_folder = '../runs/' + middle
@@ -137,6 +137,8 @@ parser.add_argument('-individual', action='store_true')
 parser.add_argument('-awsgroup', default='Daala')
 parser.add_argument('-machines', default=13)
 parser.add_argument('-mode', default='metric')
+parser.add_argument('-runid', default=get_time())
+
 args = parser.parse_args()
 
 aws_group_name = args.awsgroup
@@ -185,8 +187,6 @@ for machine in machines:
 
 slots = awsremote.get_slots(machines)
 
-# Z is added because that's what awcy uses on the end
-start_time = datetime.now().strftime("%Y-%m-%dT%H-%M-%S.%f")[:-3] + 'Z'
 
 #Make a list of the bits of work we need to do.
 #We pack the stack ordered by filesize ASC, quality ASC (aka. -v DESC)
@@ -219,7 +219,7 @@ elif args.mode == 'ab':
             work = ABWork()
             work.bpp = bpp
             work.codec = args.codec
-            work.time = start_time
+            work.runid = str(args.runid)
             work.set = args.set[0]
             work.filename = filename
             work.extra_options = extra_options

--- a/rd_tool.py
+++ b/rd_tool.py
@@ -81,10 +81,7 @@ class ABWork:
         self.failed = False
     def execute(self, slot):
         work = self
-        if self.individual:
-            input_path = '/mnt/media/'+work.filename
-        else:
-            input_path = '/mnt/media/'+work.set+'/'+work.filename
+        input_path = '/mnt/media/' + work.set + '/' + work.filename
 
         try:
             slot.start_shell('/home/ec2-user/daala/tools/ab_meta_compare.sh ' + shellquote(str(self.bpp)) + ' ' + shellquote(self.time) + ' ' + work.set + ' ' + shellquote(input_path) )
@@ -223,11 +220,7 @@ elif args.mode == 'ab':
             work.bpp = bpp
             work.codec = args.codec
             work.time = start_time
-            if args.individual:
-                work.individual = True
-            else:
-                work.individual = False
-                work.set = args.set[0]
+            work.set = args.set[0]
             work.filename = filename
             work.extra_options = extra_options
             work_items.append(work)

--- a/rd_tool.py
+++ b/rd_tool.py
@@ -213,17 +213,20 @@ if args.mode == 'metric':
             work.extra_options = extra_options
             work_items.append(work)
 elif args.mode == 'ab':
-    bits_per_pixel = [x/10.0 for x in range(1, 11)]
-    for filename in video_filenames:
-        for bpp in bits_per_pixel:
-            work = ABWork()
-            work.bpp = bpp
-            work.codec = args.codec
-            work.runid = str(args.runid)
-            work.set = args.set[0]
-            work.filename = filename
-            work.extra_options = extra_options
-            work_items.append(work)
+    if video_sets[args.set[0]]['type'] == 'video':
+        print("mode `ab` isn't supported for videos. Skipping.")
+    else:
+        bits_per_pixel = [x/10.0 for x in range(1, 11)]
+        for filename in video_filenames:
+            for bpp in bits_per_pixel:
+                work = ABWork()
+                work.bpp = bpp
+                work.codec = args.codec
+                work.runid = str(args.runid)
+                work.set = args.set[0]
+                work.filename = filename
+                work.extra_options = extra_options
+                work_items.append(work)
 else:
     print('Unsupported -mode parameter.')
     sys.exit(1)

--- a/sets.json
+++ b/sets.json
@@ -1,15 +1,18 @@
 {
-  "video-1-short":
-    [
+  "video-1-short": {
+    "type": "video",
+    "sources": [
       "grandma_short.y4m",
       "akiyo_cif_short.y4m",
       "sintel_trailer_2k_short.y4m",
       "soccer_short.y4m",
       "ducks_take_off_short.y4m",
       "park_joy_short.y4m"
-    ],
-  "video-hd-1":
-    [
+    ]
+  },
+  "video-hd-1": {
+    "type": "video",
+    "sources": [
       "sintel_trailer_2k_1080p24_2s.y4m",
       "pedestrian_area_1080p25_2s.y4m",
       "station2_1080p25_2s.y4m",
@@ -17,9 +20,11 @@
       "ducks_take_off_1080p50_2s.y4m",
       "old_town_cross_1080p50_2s.y4m",
       "park_joy_1080p50_2s.y4m"
-    ],
-  "video-hd-2":
-    [
+    ]
+  },
+  "video-hd-2": {
+    "type": "video",
+    "sources": [
       "aspen_1080p_50f.y4m",
       "blue_sky_1080p25_50f.y4m",
       "crowd_run_1080p50_50f.y4m",
@@ -33,9 +38,11 @@
       "riverbed_1080p25_50f.y4m",
       "rush_hour_1080p25_50f.y4m",
       "station2_1080p25_50f.y4m"
-    ],
-  "ntt-short-1":
-    [
+    ]
+  },
+  "ntt-short-1": {
+    "type": "video",
+    "sources": [
       "BasketballPass_416x240_50_1s.y4m",
       "BlowingBubbles_416x240_50_1s.y4m",
       "BQSquare_416x240_60_1s.y4m",
@@ -54,9 +61,11 @@
       "BasketballDrive_1920x1080_50_1s.y4m",
       "Cactus_1920x1080_50_1s.y4m",
       "BQTerrace_1920x1080_60_1s.y4m"
-    ],
-  "ntt-short-1-64":
-    [
+    ]
+  },
+  "ntt-short-1-64": {
+    "type": "video",
+    "sources": [
       "BasketballPass_384x192_50_1s.y4m",
       "BlowingBubbles_384x192_50_1s.y4m",
       "BQSquare_384x192_60_1s.y4m",
@@ -75,15 +84,19 @@
       "BasketballDrive_1920x1024_50_1s.y4m",
       "Cactus_1920x1024_50_1s.y4m",
       "BQTerrace_1920x1024_60_1s.y4m"
-    ],
-  "ntt-short-1-vc-720p30":
-    [
+    ]
+  },
+  "ntt-short-1-vc-720p30": {
+    "type": "video",
+    "sources": [
       "FourPeople_1280x720_30_1s.y4m",
       "Johnny_1280x720_30_1s.y4m",
       "KristenAndSara_1280x720_30_1s.y4m"
-    ],
-  "screenshots":
-    [
+    ]
+  },
+  "screenshots": {
+    "type": "image",
+    "sources": [
       "20130119071322_Microsoft_Project_screenshot.png.y4m",
       "20130920125838_Firefox_Screenshot.png.y4m",
       "Audacity_1.3.beta_screenshot.png.y4m",
@@ -99,9 +112,11 @@
       "Piwik_screenshot_german.png.y4m",
       "Screenshot_kmeleon09.png.y4m",
       "Screenshot_lxde_ubuntu_urdu.png.y4m"
-    ],
-  "subset1":
-    [
+    ]
+  },
+  "subset1": {
+    "type": "image",
+    "sources": [
       "08-2011._Panthera_tigris_tigris_-_Texas_Park_-_Lanzarote_-TP04.y4m",
       "125_-_Québec_-_Pont_de_Québec_de_nuit_-_Septembre_2009.y4m",
       "2011-03-05_03-13_Madeira_159_Funchal,_Mercado_dos_Lavradores.y4m",
@@ -152,9 +167,11 @@
       "Washington_Monument,_Washington,_D.C._04037u_original.y4m",
       "Wasserfassstelle_von_1898_im_Schanerloch.y4m",
       "White_Dune_-_Mui_Ne.y4m"
-    ],
-  "subset2":
-    [
+    ]
+  },
+  "subset2": {
+    "type": "image",
+    "sources":  [
       "20100701_Pelpin,_cathedral,_1.y4m",
       "77_Bombay_Street_Photo_by_Sven_Fischer.y4m",
       "80_-_Machu_Picchu_-_Juin_2009_-_edit.2.y4m",
@@ -205,9 +222,11 @@
       "Vocabulaire_de_l'académie,_1832_01.y4m",
       "Zoo_de_la_Barben_20100605_048.y4m",
       "Вид_из_Green_Plaza_065.y4m"
-    ],
-  "subset3":
-    [
+    ]
+  },
+  "subset3": {
+    "type": "image",
+    "sources": [
       "020_BS_Schlösschen_gundeldingen.y4m",
       "02_568a_DA_(belg,).y4m",
       "072.Sieste.y4m",
@@ -1208,9 +1227,11 @@
       "№743+_В.Аксенов,_ВНекрасов,_ВКондырев,_Орлеан,_1985.y4m",
       "柳州市红光桥.y4m",
       "水湳經貿園區鳥瞰圖_(面台中港).y4m"
-    ],
-  "subset4":
-    [
+    ]
+  },
+  "subset4": {
+    "type": "image",
+    "sources": [
       "Flickr_-_Joost_J._Bakker_IJmuiden_(8).y4m",
       "100_Arme_der_Guan-yin_with_new_arms.y4m",
       "102nd_Infantry_Rgt._in_Laghman_province_2010-09-25.y4m",
@@ -2212,4 +2233,5 @@
       "虎丘庙会.y4m",
       "隅田公園_SUMIDA_park.y4m"
     ]
+  }
 }


### PR DESCRIPTION
This seems to work well. Works with video and with pictures. Exports the pictures or videos to `../runs/...` where the directory structure is the same as awcy uses except that the files go into subfolders called `bpp_0.1` or whatever the bpp value happened to be. The random network failure seems gone (I've run it with up to 500 pictures at a go). I think slowing that sleep timer down fixed it.

It requires daala ab scripts be updated so I'll go ahead and submit a PR for that.

@tdaede This seems to work well so I'd expect the next step is to get awcy to where it can fire off a build set?