### PR TITLE
rd_tool: default to utf-8 when loading sets

### DIFF
--- a/rd_tool.py
+++ b/rd_tool.py
@@ -6,6 +6,7 @@ import os
 import sys
 import subprocess
 import json
+import codecs
 import awsremote
 import scheduler
 
@@ -150,7 +151,7 @@ quality = {
 work_items = []
 
 #load all the different sets and their filenames
-video_sets_f = open('sets.json','r')
+video_sets_f = codecs.open('sets.json','r',encoding='utf-8')
 video_sets = json.load(video_sets_f)
 
 parser = argparse.ArgumentParser(description='Collect RD curve data.')


### PR DESCRIPTION
Fixes "UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 8211: ordinal not in range(128)"