### PR TITLE
rd_tool: log extra encoder options for posterity

### DIFF
--- a/rd_tool.py
+++ b/rd_tool.py
@@ -27,6 +27,7 @@ daala_root = os.environ['DAALA_ROOT']
 extra_options = ''
 if 'EXTRA_OPTIONS' in os.environ:
     extra_options = os.environ['EXTRA_OPTIONS']
+    print(get_time(),'Passing extra command-line options:"%s"' + extra_options)
 
 class Work:
     def __init__(self):


### PR DESCRIPTION
This change lets us see in the Job log what encoder options were used for a given run.