### PR TITLE
metrics_gather: fallback to default quality

### DIFF
--- a/metrics_gather.sh
+++ b/metrics_gather.sh
@@ -69,6 +69,10 @@ if [ -z "$CODEC" ]; then
   export CODEC=daala
 fi
 
+if [ -z "$x" ]; then
+  export x=10
+fi
+
 FILE=$1
 
 BASENAME="$(basename $FILE)-$x"


### PR DESCRIPTION
Found due to bash syntax error message when calling metrics_gather.sh directly without setting $x in the environment.