### PR TITLE
metrics_gather: simplify ENCTIME calculation

### DIFF
--- a/metrics_gather.sh
+++ b/metrics_gather.sh
@@ -174,7 +174,7 @@ FASTSSIM=$("$DUMP_FASTSSIM" -c "$FILE" "$BASENAME.y4m" 2> /dev/null | grep Total
 CIEDE=$("$DUMP_CIEDE" "$FILE" "$BASENAME.y4m" 2> /dev/null | grep Total)
 MSSSIM=$("$DUMP_MSSSIM" "$FILE" "$BASENAME.y4m" 2> /dev/null | grep Total)
 if [ -e "$TIMER_OUT" ]; then
-  ENCTIME=$(echo $(cat "$TIMER_OUT" | grep seconds | rev | cut -f1 -d ' ' | rev) + p | dc)
+  ENCTIME=$(awk '/seconds/ { s+=$4 } END { printf "%.2f", s }' "$TIMER_OUT")
 else
   ENCTIME=0
 fi


### PR DESCRIPTION
Use a single awk process to sum to columns from the $TIMER_OUT file.

N.B. only tested locally on a dummy file.
Cc: @tmatth 