### PR TITLE
Fix killing work that is running.

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -24,6 +24,7 @@ def run(work_items, slots):
                     retries = retries + 1
                     print(get_time(),'Retrying work...',retries,'of',max_retries,'retries.')
                     work_items.append(slot.work)
+                slot.clear_work()
                 taken_slots.remove(slot)
                 free_slots.append(slot)
 


### PR DESCRIPTION
Prevents cancelled running work from being restarted.
Stops work that is being cancelled from having slot.kill call kill on a previous work's subprocess (or None). slot.kill now spawns a thread that will wait for slot.start_shell to be called.
Fixes an unlikely race condition where slot.kill kills a future work's subprocess.
Fixes an unlikely race condition where a work.cancel checks for a slot, but the slot is set to None before slot.kill is called.